### PR TITLE
fix: Revise budget given category clarification

### DIFF
--- a/proposal/application.md
+++ b/proposal/application.md
@@ -61,31 +61,32 @@ _Please provide a brief justification for each category (2-3 sentences)._
 
 ## Itemized Budget and Justification
 
-1. Stipend/salary: $8000 USD
+1. Stipend/salary: $10000 USD
 
-* $7000 USD for three (3) weeks worth of Data Science Hub facilitator staff time and work integrated across the project duration.
-* $1000 USD for ten (10) hours of pixi developer time to provide a technical review of all course material.
+* The stipend will support my research, writing, and workshop design and organization time and effort over the course of the six (6) month Fellowship.
 
 2. Travel: $5000 USD
 
 * $5000 USD for travel and lodging for myself for three (3) week-long trips to the University of Wisconsin-Madison (one week for each of the workshops).
 This travel funding is needed as I work remotely from UW-Madison given my research.
-The amount requested is based off of prices for flights to Madison, Wisconsin and lodging near the University of Wisconsin-Madison in 2024.
+The amount requested is based on prices for flights to Madison, Wisconsin and lodging near the University of Wisconsin-Madison in 2024.
 
 3. Research Resources (< $10k): $10000 USD
 
-To provide travel and lodging stipends for twelve (12) supported non-local participants (participants local to UW-Madison will not need travel support) to attend a two (2) day national workshop is $833 USD per stipend (rounding down to the nearest dollar).
-This would result in a recommended participant travel and lodging stipend maximum of:
+* $4000 USD for two (2) weeks worth of Data Science Hub facilitator staff time and work integrated across the project duration.
+* $1000 USD for ten (10) hours of contracted pixi developer time to provide a technical review of all course material.
+* $5000 USD to provide lodging for ten (10) supported non-local participants (participants local to UW-Madison will not need travel support) to attend a two (2) day national workshop and attend a hosted workshop dinner.
+The projected per participant cost ($500 USD) breakdown is:
+   - $450 USD projected lodging expenses per participant in the national workshop (based on 2024 prices of affordable hotels in the University of Wisconsin-Madison area).
+   Lodging would be for three (3) nights and arranged as a group hotel block reservation to minimize cost and consolidate all participant lodging into a single expense report item.
+   - $50 USD expenses per participant in food for a workshop dinner at a local Madison restaurant.
 
-* $383 USD travel stipend for each participant to the national workshop.
-* $450 USD lodging stipend for each participant in the national workshop (based off of 2024 prices of affordable hotels in the University of Wisconsin-Madison area).
-
-As workshop participants will have variation in their travel costs the actual amount awarded for travel will fluctuate to support the maximum number of participants.
-A sponsorship request will be submitted to the UW-Madison Data Science Institute to cover any travel and lodging that can not be covered from the Research Resources budget as well as a sponsored dinner for workshop participants.
+A sponsorship request will be submitted to the UW-Madison Data Science Institute to cover any lodging that can not be covered from the Research Resources budget as well as support the dinner for workshop participants.
+In the event of DSI sponsorship, any remaining Research Resources funds will provide support for additional non-local participants.
 
 4. Other Direct Costs
 
 None
 * Room costs for the workshops at the DSH would be $400 USD per day but have been agreed to be waived for the workshops.
 
-Total Requested: $23000 USD
+Total Requested: $25000 USD

--- a/proposal/application.md
+++ b/proposal/application.md
@@ -71,7 +71,7 @@ _Please provide a brief justification for each category (2-3 sentences)._
 This travel funding is needed as I work remotely from UW-Madison given my research.
 The amount requested is based on prices for flights to Madison, Wisconsin and lodging near the University of Wisconsin-Madison in 2024.
 
-3. Research Resources (< $10k): $10000 USD
+3. Research Resources: $10000 USD
 
 * $4000 USD for two (2) weeks worth of Data Science Hub facilitator staff time and work integrated across the project duration.
 * $1000 USD for ten (10) hours of contracted pixi developer time to provide a technical review of all course material.


### PR DESCRIPTION
* Rescope stipend for my effort.
* Move Data Science Hub and pixi developer time to contracted expenses in Research Resources.
* Rescope workshop expenses to be lodging only.
   - Clarify that lodging will be a single block expense item.